### PR TITLE
Update template to .NET 10 and fix icon_path bug

### DIFF
--- a/DevcadeGame/DevcadeGame.csproj
+++ b/DevcadeGame/DevcadeGame.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>Major</RollForward>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>

--- a/publish.ps1
+++ b/publish.ps1
@@ -17,7 +17,7 @@ if ($args.Length -eq 2) {
 
     if (Test-Path $icon_path -PathType Leaf) {
         echo "Icon found. Moving to root directory"
-        Copy-Item $banner_path -Destination "."
+        Copy-Item $icon_path -Destination "."
     } else {
         echo "No file found at icon path"
         exit 1
@@ -82,7 +82,7 @@ if (Test-Path "./publish" -PathType Container) {
     Remove-Item "./publish"
 }
 
-Move-Item "./bin/Release/net6.0/linux-x64/publish" "./"
+Move-Item "./bin/Release/net10.0/linux-x64/publish" "./"
 
 Write-Host "Zipping..." -NoNewline
 Compress-Archive -Path "./publish", $banner_path, $icon_path -DestinationPath "$basename.zip"

--- a/publish.sh
+++ b/publish.sh
@@ -74,7 +74,7 @@ function package_game() {
 	mkdir -p $WORK_DIR 
 
 	# Copy assets to temporary directory
-	PUB="$GAME/bin/Release/net6.0/linux-x64/publish"
+	PUB="$GAME/bin/Release/net10.0/linux-x64/publish"
 
 	cp -r $BANNER $ICON $PUB $WORK_DIR
 


### PR DESCRIPTION
Updates the template from .NET 6.0 --> .NET 10.0 and fixes a bug in the Windows PowerShell publishing script where the icon_path was incorrectly copied from the banner_path.


Tested on: local build --> built and ran successfully